### PR TITLE
Improved Color Scheme

### DIFF
--- a/components/App.js
+++ b/components/App.js
@@ -129,9 +129,9 @@ class App extends React.Component {
               flexDirection: "column",
               justifyContent: "center",
               alignItems: "center",
-              backgroundColor: "#fefefe",
+              backgroundColor: colors.white,
               width: "100%",
-              color: "#101010",
+              color: colors.night,
             }}
           >
           

--- a/components/App.js
+++ b/components/App.js
@@ -129,9 +129,9 @@ class App extends React.Component {
               flexDirection: "column",
               justifyContent: "center",
               alignItems: "center",
-              backgroundColor: colors.washedBlue,
+              backgroundColor: "#fefefe",
               width: "100%",
-              color: colors.white,
+              color: "#101010",
             }}
           >
           

--- a/components/MapChart.js
+++ b/components/MapChart.js
@@ -69,11 +69,12 @@ class MapChart extends React.Component {
                     fill={colors.washed}
                     style={{
                       default: {
-                        fill: colors.oliveGreen,
-                        outline: "none",
+                        fill: "#ced7de",
+                        stroke: "c0d0d0",
+                        "stoke-width": "0.25px"
                       },
                       hover: {
-                        fill: colors.fadedGreen,
+                        fill: "#C1DEE7",
                         outline: "none",
                       },
                       pressed: {
@@ -107,7 +108,7 @@ class MapChart extends React.Component {
                     textAnchor="middle"
                     style={{
                       fontSize: 24,
-                      fill: colors.white,
+                      fill: "#101010",
                       cursor: "pointer",
                     }}
                     onClick={this.onClick(location)}
@@ -120,9 +121,8 @@ class MapChart extends React.Component {
                   y={24}
                   style={{
                     fontFamily: "system-ui",
-                    fill: "#FFFFFF",
-                    textShadow: "1px 1px #000000",
                     fontSize: 16,
+                    fill: "#000000",
                   }}
                 >
                   {label}

--- a/components/MapChart.js
+++ b/components/MapChart.js
@@ -69,8 +69,8 @@ class MapChart extends React.Component {
                     fill={colors.washed}
                     style={{
                       default: {
-                        fill: "#ced7de",
-                        stroke: "c0d0d0",
+                        fill: colors.washed,
+                        stroke: colors.washedDarker,
                         "stoke-width": "0.25px"
                       },
                       hover: {
@@ -108,7 +108,7 @@ class MapChart extends React.Component {
                     textAnchor="middle"
                     style={{
                       fontSize: 24,
-                      fill: "#101010",
+                      fill: colors.black,
                       cursor: "pointer",
                     }}
                     onClick={this.onClick(location)}
@@ -122,7 +122,7 @@ class MapChart extends React.Component {
                   style={{
                     fontFamily: "system-ui",
                     fontSize: 16,
-                    fill: "#000000",
+                    fill: colors.black,
                   }}
                 >
                   {label}

--- a/util/styles.js
+++ b/util/styles.js
@@ -6,5 +6,6 @@ export const colors = {
   fadedGreen: "#93a889",
   washedBlue: "#00699440",
   washed: "#ced7de",
+  washedDarker: "c0d0d0",
   white: "#ffffff",
 };


### PR DESCRIPTION
Addresses https://github.com/dvargas92495/covilla/issues/16

Uses the same colors as before, but changes the emphasis (darker parts) from the background and the map itself, to the title and the map markers. 

<img width="1771" alt="Screen Shot 2020-11-25 at 3 58 56 PM" src="https://user-images.githubusercontent.com/6342435/100282729-1f9e2a80-2f3a-11eb-842d-033a6221d040.png">